### PR TITLE
Made these changes:

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF line endings for Bash scripts.   On Windows the rest of the source
+# files will typically have CR+LF endings (Git default on Windows), but Bash
+# scripts need to have LF endings to work (under Cygwin), thus override to force
+# that.
+gradlew text eol=lf
+*.sh text eol=lf

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,5 @@ war {
 gretty {
     servletContainer = 'jetty9'
     loggingLevel = 'debug'
+    contextPath = '/JavaAPIApp'
 }

--- a/build/serverBaseDir_jetty9/webapps-exploded/JavaAPIApp/webapp/index.html
+++ b/build/serverBaseDir_jetty9/webapps-exploded/JavaAPIApp/webapp/index.html
@@ -29,12 +29,13 @@
                     <li class="active"><a href="#">Home</a></li>
                     <li><a href="/JavaAPIApp/swagger-ui">Swagger UI</a></li>
                     <li><a href="/JavaAPIApp/api/swagger.json">Swagger JSON</a></li>
-                    <li><a href="#" onclick="generate()">Generate C# Client</a></li>
+                    <!-- <li><a href="#" onclick="generate()">Generate C# Client</a></li> -->
                 </ul>
             </div>
         </div>
     </nav>
     <div id="dataForm" style="display: none">
+        <!-- makeCode is no longer used; now you should download AutoRest from https://github.com/Azure/autorest to use it -->
         <form id="makeCode" action="https://autorestapi.azurewebsites.net/generate" method="POST">
             <input type="hidden" id="codegenerator" name="CodeGenerator" value="CSharp" />
             <input type="hidden" id="modeler" name="Modeler" value="Swagger" />

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -29,12 +29,13 @@
                     <li class="active"><a href="#">Home</a></li>
                     <li><a href="/JavaAPIApp/swagger-ui">Swagger UI</a></li>
                     <li><a href="/JavaAPIApp/api/swagger.json">Swagger JSON</a></li>
-                    <li><a href="#" onclick="generate()">Generate C# Client</a></li>
+                    <!-- <li><a href="#" onclick="generate()">Generate C# Client</a></li> -->
                 </ul>
             </div>
         </div>
     </nav>
     <div id="dataForm" style="display: none">
+        <!-- makeCode is no longer used; now you should download AutoRest from https://github.com/Azure/autorest to use it -->
         <form id="makeCode" action="https://autorestapi.azurewebsites.net/generate" method="POST">
             <input type="hidden" id="codegenerator" name="CodeGenerator" value="CSharp" />
             <input type="hidden" id="modeler" name="Modeler" value="Swagger" />


### PR DESCRIPTION
- Fixed build.gradle to include contextPath = '/JavaAPIApp'.  Without that,
  the newest versions of the Gretty plugin won't give the WAR the right name
  (instead defaulting to the directory name), so it won't work
- Changed index.html to remove the "Generate C# client" UI (as that was only
  a temporary thing that Brady setup for a demo).  Brady just made the same
  change to the .Net sample.
- Add .gitattributes, which is just a convenience thing so folks using cygwin
  on Windows (like myself) will have a gradlew Bash script file that works OK,
  with the right kind of line endings (LF)
